### PR TITLE
Refactor and support new Concourse version

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,0 +1,23 @@
+name: Python application
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r test-requirements.txt
+    - name: Lint and check code
+      run: |
+        ./check_code -v

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 dist
 build
 concoursepy.egg-info
+.idea/
+.vscode/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include requirements.txt
+include test-requirements.txt
+include check_code
+include pylintrc

--- a/README.md
+++ b/README.md
@@ -13,4 +13,9 @@ import concoursepy
 
 ci = concoursepy.api('https://ci.example.com', 'username', 'password')
 print(ci.jobs('example_pipeline'))
+
+# Or with token istead of username and password:
+ci = concoursepy.api('https://ci.example.com', token='SomeLongTokenString')
+print(ci.jobs('example_pipeline'))
+
 ```

--- a/check_code
+++ b/check_code
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+CURDIR=$(pwd)
+SELFDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+cd $SELFDIR
+python3 -m pycodestyle concoursepy
+if [[ $1 = '-v' ]]; then
+    python3 -m pylint --rcfile=pylintrc --reports=yes concoursepy
+else
+    python3 -m pylint --rcfile=pylintrc concoursepy
+fi
+cd $CURDIR

--- a/concoursepy/__init__.py
+++ b/concoursepy/__init__.py
@@ -1,3 +1,3 @@
-name = "concoursepy"
+from concoursepy.api import Api as api
 
-from concoursepy.api import api
+name = "concoursepy"

--- a/concoursepy/api.py
+++ b/concoursepy/api.py
@@ -1,215 +1,463 @@
+import collections
 import json
+from os.path import join as pathjoin
+import re
+from urllib.parse import urljoin
+
 import requests
+from requests.exceptions import HTTPError
 
 
-class api:
-    def __init__(self, url, username, password):
+LOGIN_REG = re.compile(r'"/sky/issuer/auth/local.*?"')
+
+
+class Api:
+    def __init__(self, url, username=None, password=None, token=None):
         self.url = url
+        self.api_path = '/api/v1/'
         self.username = username
         self.password = password
-        self.ATC_AUTH = ""
+        self.ATC_AUTH = token
+        self.session = None
         self.auth()
 
+    def list_teams(self):
+        return self.get('teams')
+
+    def get_team(self, team_name):
+        return self.get('teams/%s' % team_name)
+
     def get_config(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/config" % (self.url, team_name, pipeline_name))
+        return self.get(
+            "teams/%s/pipelines/%s/config" % (team_name, pipeline_name)
+        )
 
     def jobs(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/jobs" % (self.url, team_name, pipeline_name))
+        return self.get(
+            "teams/%s/pipelines/%s/jobs" % (team_name, pipeline_name)
+        )
 
     def list_builds(self):
-        return self.get("%s/api/v1/builds" % (self.url))
+        return self.get("builds")
 
     def get_build(self, build_id):
-        return self.get("%s/api/v1/build/%s" % (self.url, build_id))
+        return self.get("build/%s" % build_id)
 
     def build(self, build_id):
         """Leaving this here for backwards compatibility."""
         return self.get_build(build_id)
 
     def get_build_plan(self, build_id):
-        return self.get("%s/api/v1/builds/%s/plan" % (self.url, build_id))
+        return self.get("builds/%s/plan" % build_id)
 
     def build_plan(self, build_id):
         """Leaving this here for backwards compatibility."""
         return self.get_build_plan(build_id)
 
     def send_input_to_build_plan(self, build_id, plan_id):
-        return self.put("%s/api/v1/builds/%s/plan/%s/input" % (self.url, build_id, plan_id))
+        return self.put("builds/%s/plan/%s/input" % (build_id, plan_id))
 
     def read_output_from_build_plan(self, build_id, plan_id):
-        return self.get("%s/api/v1/builds/%s/plan/%s/input" % (self.url, build_id, plan_id))
+        return self.get("builds/%s/plan/%s/input" % (build_id, plan_id))
 
     def build_events(self, build_id):
-        return self.get("%s/api/v1/builds/%s/events" % (self.url, build_id))
+        return self.get("builds/%s/events" % build_id)
 
     def build_resources(self, build_id):
-        return self.get("%s/api/v1/builds/%s/resources" % (self.url, build_id))
+        return self.get("builds/%s/resources" % build_id)
 
     def abort_build(self, build_id):
-        return self.put("%s/api/v1/builds/%s/abort" % (self.url, build_id))
+        return self.put("builds/%s/abort" % build_id)
 
-    def get_build_preperation(self, build_id):
-        return self.get("%s/api/v1/builds/%s/preperation" % (self.url, build_id))
+    def get_build_preparation(self, build_id):
+        return self.get("builds/%s/preparation" % build_id)
 
     def list_all_jobs(self):
-        return self.get("%s/api/v1/jobs")
+        return self.get("jobs")
 
     def list_jobs(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/jobs" % (self.url, team_name, pipeline_name))
+        return self.get(
+            "teams/%s/pipelines/%s/jobs" % (team_name, pipeline_name)
+        )
 
-    def get_job(self, pipeline_name, job_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/jobs/%s")
+    def get_job(self, team_name, pipeline_name, job_name):
+        return self.get(
+            "teams/%s/pipelines/%s/jobs/%s" % (
+                team_name, pipeline_name, job_name
+            )
+        )
 
     def list_job_builds(self, team_name, pipeline_name, job_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/jobs/%s/builds" % (self.url, team_name, pipeline_name, job_name))
+        return self.get(
+            "teams/%s/pipelines/%s/jobs/%s/builds" % (
+                team_name, pipeline_name, job_name
+            )
+        )
 
     def create_job_build(self, team_name, pipeline_name, job_name):
-        return self.post("%s/api/v1/teams/%s/pipelines/%s/jobs/%s/builds" % (self.url, team_name, pipeline_name, job_name))
+        return self.post(
+            "teams/%s/pipelines/%s/jobs/%s/builds" % (
+                team_name, pipeline_name, job_name
+            )
+        )
 
-    def trigger(self, pipeline_name, job_name):
+    def trigger(self, team_name, pipeline_name, job_name):
         """Leaving this here for backwards compatibility."""
-        return self.create_job_build(pipeline_name, job_name)
+        return self.create_job_build(team_name, pipeline_name, job_name)
 
     def list_job_inputs(self, team_name, pipeline_name, job_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/jobs/%s/inputs" % (self.url, team_name, pipeline_name, job_name))
+        return self.get(
+            "teams/%s/pipelines/%s/jobs/%s/inputs" % (
+                team_name, pipeline_name, job_name
+            )
+        )
 
     def get_job_build(self, team_name, pipeline_name, job_name, build_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/jobs/%s/builds/%s" % (self.url, team_name, pipeline_name, job_name, build_name))
+        return self.get(
+            "teams/%s/pipelines/%s/jobs/%s/builds/%s" % (
+                team_name, pipeline_name, job_name, build_name
+            )
+        )
 
     def pause_job(self, team_name, pipeline_name, job_name):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/jobs/%s/pause" % (self.url, team_name, pipeline_name, job_name))
+        return self.put(
+            "teams/%s/pipelines/%s/jobs/%s/pause" % (
+                team_name, pipeline_name, job_name
+            )
+        )
 
     def unpause_job(self, team_name, pipeline_name, job_name):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/jobs/%s/unpause" % (self.url, team_name, pipeline_name, job_name))
+        return self.put(
+            "teams/%s/pipelines/%s/jobs/%s/unpause" % (
+                team_name, pipeline_name, job_name
+            )
+        )
 
     def job_badge(self, team_name, pipeline_name, job_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/jobs/%s/badge" % (self.url, team_name, pipeline_name, job_name))
+        return self.get(
+            "teams/%s/pipelines/%s/jobs/%s/badge" % (
+                team_name, pipeline_name, job_name
+            )
+        )
 
     def main_job_badge(self, pipeline_name, job_name):
-        return self.get("%s/api/v1/pipelines/%s/jobs/%s/badge" % (self.url, pipeline_name, job_name))
+        return self.get(
+            "pipelines/%s/jobs/%s/badge" % (pipeline_name, job_name)
+        )
 
     def list_all_pipelines(self):
-        return self.get("%s/api/v1/pipelines" % self.url)
+        return self.get("pipelines")
 
     def list_pipelines(self, team_name):
-        return self.get("%s/api/v1/teams/%s/pipelines" % (self.url, team_name))
+        return self.get("teams/%s/pipelines" % team_name)
 
     def get_pipeline(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s" % (self.url, team_name, pipeline_name))
+        return self.get("teams/%s/pipelines/%s" % (team_name, pipeline_name))
 
     def pause_pipeline(self, team_name, pipeline_name):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/pause" % (self.url, team_name, pipeline_name))
+        return self.put(
+            "teams/%s/pipelines/%s/pause" % (team_name, pipeline_name)
+        )
 
     def unpause_pipeline(self, team_name, pipeline_name):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/unpause" % (self.url, team_name, pipeline_name))
+        return self.put(
+            "teams/%s/pipelines/%s/unpause" % (team_name, pipeline_name)
+        )
 
     def list_pipeline_builds(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/builds" % (self.url, team_name, pipeline_name))
+        return self.get(
+            "teams/%s/pipelines/%s/builds" % (team_name, pipeline_name)
+        )
 
     def pipeline_badge(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/badge" % (self.url, team_name, pipeline_name))
+        return self.get(
+            "teams/%s/pipelines/%s/badge" % (team_name, pipeline_name)
+        )
 
     def list_all_resources(self):
-        return self.get("%s/api/v1/resources" % self.url)
+        return self.get("resources")
 
     def list_resources(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resources" % (self.url, team_name, pipeline_name))
+        return self.get(
+            "teams/%s/pipelines/%s/resources" % (team_name, pipeline_name)
+        )
 
     def list_resource_types(self, team_name, pipeline_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resource-types" % (self.url, team_name, pipeline_name))
+        return self.get(
+            "teams/%s/pipelines/%s/resource-types" % (team_name, pipeline_name)
+        )
 
     def get_resource(self, team_name, pipeline_name, resource_name):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resources/%s" % (self.url, team_name, pipeline_name, resource_name))
+        return self.get(
+            "teams/%s/pipelines/%s/resources/%s" % (
+                team_name, pipeline_name, resource_name
+            )
+        )
 
-    def list_resource_versions(self, team_name, pipeline_name, resource_name, limit=100):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions?limit=%s" % (self.url, team_name, pipeline_name, resource_name, limit))
+    def list_resource_versions(
+        self, team_name, pipeline_name, resource_name, limit=100
+    ):
+        return self.get(
+            "teams/%s/pipelines/%s/resources/%s/versions?limit=%s" % (
+                team_name, pipeline_name, resource_name, limit
+            )
+        )
 
     def versions(self, team_name, pipeline_name, resource_name, limit=100):
         """Leaving this here for backwards compatibility."""
-        return self.list_resource_versions(team_name, pipeline_name, resource_name, limit)
+        return self.list_resource_versions(
+            team_name, pipeline_name, resource_name, limit
+        )
 
-    def get_resource_version(self, team_name, pipeline_name, resource_name, resource_version_id):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s" % (self.url, team_name, pipeline_name, resource_name, resource_version_id))
+    def get_resource_version(
+        self, team_name, pipeline_name, resource_name, resource_version_id
+    ):
+        return self.get(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s" % (
+                team_name, pipeline_name, resource_name, resource_version_id
+            )
+        )
 
-    def enable_resource_version(self, team_name, pipeline_name, resource_name, resource_version_id):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s/enable" % (self.url, team_name, pipeline_name, resource_name, resource_version_id))
+    def enable_resource_version(
+        self, team_name, pipeline_name, resource_name, resource_version_id
+    ):
+        return self.put(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s/enable" % (
+                team_name, pipeline_name, resource_name, resource_version_id
+            )
+        )
 
-    def enable(self, team_name,  pipeline_name, resource_name, resource_version_id):
-        return self.enable_resource_version(pipeline_name, team_name, resource_name, resource_version_id)
+    def enable(
+        self, team_name, pipeline_name, resource_name, resource_version_id
+    ):
+        return self.enable_resource_version(
+            team_name, pipeline_name, resource_name, resource_version_id
+        )
 
-    def disable_resource_version(self, team_name, pipeline_name, resource_name, resource_version_id):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s/disable" % (self.url, team_name, pipeline_name, resource_name, resource_version_id))
+    def disable_resource_version(
+        self, team_name, pipeline_name, resource_name, resource_version_id
+    ):
+        return self.put(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s/disable" % (
+                team_name, pipeline_name, resource_name, resource_version_id
+            )
+        )
 
-    def disable(self, team_name, pipeline_name, resource_name, resource_version_id):
-        return self.disable_resource_version(team_name, pipeline_name, resource_name, resource_version_id)
+    def disable(
+        self, team_name, pipeline_name, resource_name, resource_version_id
+    ):
+        return self.disable_resource_version(
+            team_name, pipeline_name, resource_name, resource_version_id
+        )
 
-    def pin_resource_version(self, team_name, pipeline_name, resource_name, resource_config_version_id):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s/pin" % (self.url, team_name, pipeline_name, resource_name, resource_config_version_id))
+    def pin_resource_version(
+        self, team_name, pipeline_name, resource_name,
+        resource_config_version_id
+    ):
+        return self.put(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s/pin" % (
+                team_name, pipeline_name, resource_name,
+                resource_config_version_id
+            )
+        )
 
-    def unpin_resource_version(self, team_name, pipeline_name, resource_name, resource_config_version_id):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s/unpin" % (self.url, team_name, pipeline_name, resource_name, resource_config_version_id))
+    def unpin_resource_version(
+        self, team_name, pipeline_name, resource_name,
+        resource_config_version_id
+    ):
+        return self.put(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s/unpin" % (
+                team_name, pipeline_name, resource_name,
+                resource_config_version_id
+            )
+        )
 
-    def list_builds_with_version_as_input(self, team_name, pipeline_name, resource_name, resource_id):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s/input_to" % (self.url, team_name, pipeline_name, resource_name, resource_id))
+    def list_builds_with_version_as_input(
+        self, team_name, pipeline_name, resource_name, resource_id
+    ):
+        return self.get(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s/input_to" % (
+                team_name, pipeline_name, resource_name, resource_id
+            )
+        )
 
-    def input_to(self, pipeline_name, resource_name, resource_id):
+    def input_to(self, team_name, pipeline_name, resource_name, resource_id):
         """Leaving this here for backwards compatibility."""
-        return self.list_builds_with_version_as_input(pipeline_name, resource_name, resource_id)
+        return self.list_builds_with_version_as_input(
+            team_name, pipeline_name, resource_name, resource_id
+        )
 
-    def list_builds_with_version_as_output(self, team_name, pipeline_name, resource_name, resource_id):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s/output_to" % (self.url, team_name, pipeline_name, resource_name, resource_id))
+    def list_builds_with_version_as_output(
+        self, team_name, pipeline_name, resource_name, resource_id
+    ):
+        return self.get(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s/output_to" % (
+                team_name, pipeline_name, resource_name, resource_id
+            )
+        )
 
-    def output_of(self, pipeline_name, resource_name, resource_id):
+    def output_of(self, team_name, pipeline_name, resource_name, resource_id):
         """Leaving this here for backwards compatibility."""
-        return self.list_builds_with_version_as_output(pipeline_name, resource_name, resource_id)
+        return self.list_builds_with_version_as_output(
+            team_name, pipeline_name, resource_name, resource_id
+        )
 
-    def get_resource_causality(self, team_name, pipeline_name, resource_name, resource_version_id):
-        return self.get("%s/api/v1/teams/%s/pipelines/%s/resources/%s/versions/%s/causality" % (self.url, team_name, pipeline_name, resource_name, resource_version_id))
+    def get_resource_causality(
+        self, team_name, pipeline_name, resource_name, resource_version_id
+    ):
+        return self.get(
+            "teams/%s/pipelines/%s/resources/%s/versions/%s/causality" % (
+                team_name, pipeline_name, resource_name, resource_version_id
+            )
+        )
 
     def pause_resource(self, team_name, pipeline_name, resource_name):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/resources/%s/pause" % (self.url, team_name, pipeline_name, resource_name))
+        return self.put(
+            "teams/%s/pipelines/%s/resources/%s/pause" % (
+                team_name, pipeline_name, resource_name
+            )
+        )
 
     def unpause_resource(self, team_name, pipeline_name, resource_name):
-        return self.put("%s/api/v1/teams/%s/pipelines/%s/resources/%s/unpause" % (self.url, team_name, pipeline_name, resource_name))
+        return self.put(
+            "teams/%s/pipelines/%s/resources/%s/unpause" % (
+                team_name, pipeline_name, resource_name
+            )
+        )
+
+    def _close_session(self):
+        if isinstance(self.session, requests.Session):
+            self.session.close()
+        self.session = None
+
+    def _set_new_session(self):
+        self._close_session()
+        self.session = requests.Session()
+        return self.session
+
+    def _get_skymarshal_auth(self):
+        cookies_dict = self.session.cookies.get_dict()
+        for key in ('skymarshal_auth', 'skymarshal_auth0'):
+            if key in cookies_dict:
+                return cookies_dict[key].split('"')[1].split()[1]
+        # We did not find a token:
+        self._close_session()
+        raise ValueError("Couldn't read Token")
+
+    def _make_api_url(self, path):
+        """Return the api's full  url.
+
+        If `path` does not have a leading slash self.api_path is prepended and
+        we return something like '%s/%s/%s' % (self.url, self.api_path, path)
+
+        If `path` has a leading slash self.api_path is not prepended and
+        we return something like '%s/%s/%s' % (self.url, path)
+        """
+        return urljoin(self.url, pathjoin(self.api_path, path))
+
+    @staticmethod
+    def _get_login_post_path(html_txt):
+        return LOGIN_REG.search(html_txt).group().strip('"')
+
+    @property
+    def has_username_and_passwd(self):
+        return self.username is not None and self.password is not None
 
     def auth(self):
-        self.ATC_AUTH = None
-        session = requests.Session()
-        r = session.get("%s/sky/login" % self.url)
-        if r.status_code == 200:
-            post_url = list(filter(lambda x: '/sky/issuer/auth/local' in x, r.text.split("\n")))[0].strip().split('"')[1]
-            r = session.post("%s%s" % (self.url, post_url), data={'login': self.username, 'password': self.password})
-            if "invalid username and password" in r.text:
-                raise(ValueError("authentication failure"))
-            if r.status_code == requests.codes.ok:
-                self.ATC_AUTH = session.cookies.get_dict()['skymarshal_auth'].split('"')[1].split()[1]
+        if self.has_username_and_passwd:
+            self.ATC_AUTH = None
+            session = self._set_new_session()
+            r = session.get(urljoin(self.url, "/sky/login"))
+            if r.status_code == 200:
+                post_path = self._get_login_post_path(r.text)
+                r = session.post(
+                    urljoin(self.url, post_path),
+                    data={'login': self.username, 'password': self.password}
+                )
+                try:
+                    r.raise_for_status()
+                except HTTPError:
+                    self._close_session()
+                    raise
+                else:
+                    # Yes, this case does not raise any HTTPError, the return
+                    # code is 200...
+                    if "invalid username and password" in r.text:
+                        raise ValueError("Invalid username and password")
+                    if r.status_code == requests.codes.ok:
+                        self.ATC_AUTH = self._get_skymarshal_auth()
+                    else:
+                        self._close_session()
         if self.ATC_AUTH:
             return True
         return False
 
-    def get(self, url):
-        r = requests.get(url, headers={'Content-Type': 'application/json', 'Authorization': "Bearer %s" % self.ATC_AUTH})
-        if r.status_code == 401 or r.text == 'not authorized':
+    @property
+    def headers(self):
+        if (
+            hasattr(self.session, 'headers')
+            and isinstance(self.session.headers, collections.Mapping)
+            and hasattr(self.session.headers, 'copy')
+        ):
+            headers = self.session.headers.copy()
+        else:
+            headers = {}
+
+        headers['Content-Type'] = 'application/json'
+        if self.ATC_AUTH is not None and 'Authorization' not in headers:
+            headers['Authorization'] = "Bearer %s" % self.ATC_AUTH
+        return headers
+
+    @property
+    def requests(self):
+        if self.session is not None:
+            return self.session
+        return requests
+
+    @staticmethod
+    def _is_response_ok(response):
+        if response.status_code == 401 or response.text == 'not authorized':
+            return False
+        return True
+
+    def get(self, path):
+        url = self._make_api_url(path)
+        r = self.requests.get(url, headers=self.headers)
+        if not self._is_response_ok(r) and self.has_username_and_passwd:
             self.auth()
-            r = requests.get(url, headers={'Content-Type': 'application/json', 'Authorization': "Bearer %s" % self.ATC_AUTH})
+            r = self.requests.get(url, headers=self.headers)
         if r.status_code == requests.codes.ok:
             return json.loads(r.text)
+        else:
+            r.raise_for_status()
         return False
 
-    def post(self, url, post_data):
-        r = requests.post(url, headers={'Content-Type': 'application/json', 'Authorization': "Bearer %s" % self.ATC_AUTH}, data=post_data)
-        if r.status_code == 401 or r.text == 'not authorized':
+    def post(self, path, data=None):
+        url = self._make_api_url(path)
+        kwargs = {'headers': self.headers}
+        if data is not None:
+            kwargs['data'] = data
+        r = self.requests.post(url, **kwargs)
+        if not self._is_response_ok(r) and self.has_username_and_passwd:
             self.auth()
-            r = requests.post(url, headers={'Content-Type': 'application/json', 'Authorization': "Bearer %s" % self.ATC_AUTH}, data=post_data)
+            r = self.requests.post(url, **kwargs)
         if r.status_code == requests.codes.ok:
             return json.loads(r.text)
+        else:
+            r.raise_for_status()
         return False
 
-    def put(self, url):
-        r = requests.put(url, headers={'Content-Type': 'application/json', 'Authorization': "Bearer %s" % self.ATC_AUTH})
-        if r.status_code == 401 or r.text == 'not authorized':
+    def put(self, path, data=None):
+        url = self._make_api_url(path)
+        kwargs = {'headers': self.headers}
+        if data is not None:
+            kwargs['data'] = data
+        r = self.requests.put(url, **kwargs)
+        if not self._is_response_ok(r) and self.has_username_and_passwd:
             self.auth()
-            r = requests.put(url, headers={'Content-Type': 'application/json', 'Authorization': "Bearer %s" % self.ATC_AUTH})
+            r = self.requests.put(url, **kwargs)
         if r.status_code == requests.codes.ok:
             return True
+        else:
+            r.raise_for_status()
         return False

--- a/concoursepy/api.py
+++ b/concoursepy/api.py
@@ -41,7 +41,7 @@ class Api:
         return self.get("builds")
 
     def get_build(self, build_id):
-        return self.get("build/%s" % build_id)
+        return self.get("builds/%s" % build_id)
 
     def build(self, build_id):
         """Leaving this here for backwards compatibility."""

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,106 @@
+[MASTER]
+profile=no
+persistent=yes
+ignore=migrations
+
+
+[MESSAGES CONTROL]
+# C0103 Invalid %s name "%s"
+# C0111 Missing docstring
+# C0302 Too many lines in module
+# C0330 Wrong hanging indentation before block (We let pep8 check this)
+# E0611 No name %r in module %r
+# E1101 %s %r has no %r member
+# F0401 Unable to import %s
+# I0011 Warning locally suppressed using disable-msg
+# I0012 Warning locally suppressed using disable-msg
+# R0123 Comparison to literal
+# R0201 Method could be a function
+# R0901 Too many ancestors
+# R0902 Too many instance attributes
+# R0904 Too many public methods
+# R0911 Too many return statements
+# R0912 Too many branches
+# R0914 Too many local variables
+# R0915 Too many statements
+# R1705 Unnecessary "else" after "return"
+# R1710 inconsistent-return-statements
+# W0142 Used * or * magic* Used when a function or method is called using *args or **kwargs to dispatch arguments.
+# W0212 Access to a protected member %s of a client class
+# W0223 Method %r is abstract in class %r but is not overridden
+# W0232 Class has no __init__ method Used when a class has no __init__ method, neither its parent classes.
+# W0403 Relative import '%s', should be '%s'
+# W0511 Used when a warning note as FIXME or XXX is detected.
+# W0613 Unused argument %r Used when a function or method argument is not used.
+# W0702 No exception's type specified Used when an except clause doesn't specify exceptions type to catch.
+# W0704 Except doesn't do anything Used when an except clause does nothing but "pass" and there is no "else" clause
+# W1113 keyword-arg-before-vararg
+# example:
+# disable=C0111,I0011,I0012,R0201,W0142,W0212,W0232,W0613,W0702,W0704
+# or:
+# disable=I0011,I0012,W0142,W0212,W0232
+disable=C0103,C0111,C0302,C0330,E0611,E1101,I0011,I0012,R0123,R0901,R0902,R0904,R0911,R0912,R0914,R0915,R1705,R1710,W0142,W0212,W0223,W0403,W0511,W0613,W0702,W0704,W1113
+
+
+[REPORTS]
+include-ids=yes
+output-format=parseable
+#reports=yes
+
+
+[BASIC]
+#no-docstring-rgx=__.*__|_.*
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|logger|register|urlpatterns)$
+method-rgx=([a-z_][a-z0-9_]{2,30}|setUp|tearDown|test_[a-z0-9_]{2,60}|assert[a-zA-Z0-9]{2,30})$
+#good-names=_,i,j,k,e,v,db,qs,pk
+good-names=_,i,j,k,e,v,by,fp,td,tr
+
+
+[TYPECHECK]
+ignore-mixin-members=yes
+#ignored-classes=SQLObject,WSGIRequest
+#zope=no
+#generated-members=objects,DoesNotExist,id,pk,_meta,base_fields,context
+
+
+[VARIABLES]
+#init-import=no
+#dummy-variables-rgx=_|dummy
+#additional-builtins=
+
+
+[SIMILARITIES]
+#min-similarity-lines=6
+#ignore-comments=yes
+#ignore-docstrings=yes
+ignore-imports=yes
+
+
+[MISCELLANEOUS]
+notes=FIXME,XXX,TODO
+
+
+[FORMAT]
+max-line-length=1000
+max-module-lines=500
+indent-string='    '
+
+
+[CLASSES]
+#defining-attr-methods=__init__,__new__,setUp
+
+
+[DESIGN]
+max-args=10
+max-locals=15
+max-returns=6
+max-branchs=12
+max-statements=50
+max-parents=7
+max-attributes=7
+min-public-methods=0
+max-public-methods=50
+
+
+[IMPORTS]
+#deprecated-modules=regsub,TERMIOS,Bastion,rexec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+sseclient-py

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,22 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
+def read_requirements(filename):
+    with open(filename) as fh:
+        lines = fh.readlines()
+    # remove comments
+    lines = [line.split('#')[0] for line in lines]
+    # remove trailing spaces
+    lines = [line.strip() for line in lines]
+    # remove empty lines
+    lines = [line for line in lines if line]
+    return lines
+
+
 setuptools.setup(
     name="concoursepy",
-    version="0.0.10",
+    version="0.0.20",
     author="Alex Arwine",
     author_email="arwineap@gmail.com",
     description="library to interface with concourse",
@@ -13,9 +26,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/arwineap/concoursepy",
     packages=setuptools.find_packages(),
-    install_requires=[
-        'requests'
-    ],
+    install_requires=read_requirements('requirements.txt'),
+    tests_require=read_requirements('test-requirements.txt'),
+    include_package_data=True,
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+pycodestyle
+pylint


### PR DESCRIPTION
Newer versions of Concourse return the Bearer token in the skymarshal_auth0
cookie instead of skymarshal_auth.

Adding list_teams and get_team.

We now allow working with a token only istead of login/password.

We should never concatenate urls with string formating because if a user gives
a trailing slash, with string formating it doesn't work. We now use
urllib.parse.urljoin which is designed to solve this issue.
Same issue with path joining, the right way to go is by using os.path.join
instead.

We also add linting and code checking.