### PR TITLE
Allow access to sse client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read_requirements(filename):
 
 setuptools.setup(
     name="concoursepy",
-    version="0.0.20",
+    version="0.0.30",
     author="Alex Arwine",
     author_email="arwineap@gmail.com",
     description="library to interface with concourse",


### PR DESCRIPTION
Users might want to access the sse client when retrieving build events in
order to manually close the client.